### PR TITLE
Update apple-touch-icon sizes

### DIFF
--- a/app/_includes/partials/meta.html
+++ b/app/_includes/partials/meta.html
@@ -36,9 +36,9 @@
 <link rel="publisher" href="https://plus.google.com/{{ site.author.googleid }}">
 
 <link rel="apple-/touch-icon-precomposed" href="/touch-icon-iphone.png"/>
-<link rel="apple-/touch-icon-precomposed" sizes="72x72" href="/touch-icon-ipad.png"/>
-<link rel="apple-/touch-icon-precomposed" sizes="114x114" href="/touch-icon-iphone-retina.png"/>
-<link rel="apple-/touch-icon-precomposed" sizes="144x144" href="/touch-icon-ipad-retina.png"/>
+<link rel="apple-/touch-icon-precomposed" sizes="76x76" href="/touch-icon-ipad.png"/>
+<link rel="apple-/touch-icon-precomposed" sizes="120x120" href="/touch-icon-iphone-retina.png"/>
+<link rel="apple-/touch-icon-precomposed" sizes="152x152" href="/touch-icon-ipad-retina.png"/>
 <link rel="shortcut icon" href="/favicon.ico">
 
 <link rel="author" content="humans.txt" />


### PR DESCRIPTION
The information for the new icon sizes is based off of this document: https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
